### PR TITLE
Issue #10 Refactored code and added unit test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,18 +50,6 @@ module.exports = function gruntConf(grunt) {
           tmp: ['test/fixtures/other-line-ends-windows.txt']
         }
       }
-      /*
-      failWhenTrimmed: {
-        options: {
-          failIfTrimmed: true
-        },
-        files: {
-          tmp: [
-            'test/fixtures/fail-when-trimmed.txt'
-          ]
-        }
-      }
-      */
     },
 
     // Unit tests.

--- a/tasks/trimtrailingspaces.js
+++ b/tasks/trimtrailingspaces.js
@@ -26,6 +26,17 @@ module.exports = function trimtrailingspaces(grunt) {
     return destination;
   };
 
+  const logResult = (changedFileCount, options) => {
+    if (changedFileCount > 0) {
+      grunt.log.ok(changedFileCount + ' file' + (changedFileCount === 1 ?
+        '' :
+        's') + ' had whitespace trimmed.');
+      if (options.failIfTrimmed) {
+        grunt.fail.warn(options.failMsg || 'The failIfTrimmed option is set to true.', 6);
+      }
+    }
+  };
+
   grunt.registerMultiTask('trimtrailingspaces', 'Removing the trailing spaces', function register() {
 
     // Default options extended with user defined
@@ -71,14 +82,6 @@ module.exports = function trimtrailingspaces(grunt) {
       '' :
       's') + ' free of trailing whitespace.');
 
-    if (changedFileCount > 0) {
-      grunt.log.ok(changedFileCount + ' file' + (changedFileCount === 1 ?
-        '' :
-        's') + ' had whitespace trimmed.');
-      if (options.failIfTrimmed) {
-        grunt.fail.warn(options.failMsg || 'The failIfTrimmed option is set to true.', 6);
-      }
-    }
+    logResult(changedFileCount, options);
   });
-
 };

--- a/test/trimtrailingspaces_test.js
+++ b/test/trimtrailingspaces_test.js
@@ -76,28 +76,19 @@ exports.trimtrailingspaces = {
     test.equals(actual, expected, 'Windows line endings respected');
 
     test.done();
-  }
+  },
 
-  /*
+  
   testFailWhenTrimmed: function(test) {
     test.expect(1);
 
-    // Save original API
-    var gruntWarn = grunt.fail.warn;
-
-    // Rewite stub
-    grunt.fail.warn = function (msg, code) {
-      test.equals(code, 6, 'Failed task specifies error code as defined in the task registration');
-    };
-    
-    // Run task
-    grunt.option('force', true);
-    grunt.task.run('trimtrailingspaces:failWhenTrimmed');
-
-    // Restore original API
-    grunt.fail.warn = gruntWarn;
-
-    test.done();
-  },
-  */
+    grunt.util.spawn({
+      grunt: true,
+      args: ['trimtrailingspaces:failWhenTrimmed']
+    }, function(err, result) {
+      test.equals(result.code, 3, 'failIfTrimmed warning code');
+      test.done();
+    });
+  }
+  
 };


### PR DESCRIPTION
- eslint was complaining that the register function was too long.
So I extracted the final IF to a new method.
- The strategy to test a grunt warning is to invoke a grunt subprocess
from nodeunit. This is done by grunt.util.spawn. If you don't use it,
`grunt test` will actually receive the message and always fails the test.